### PR TITLE
fix: Use relative path for script in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/index.tsx"></script>
+    <script type="module" src="./src/index.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
I changed the script source path in index.html from absolute (`/src/index.tsx`) to relative (`./src/index.tsx`).

This allows the Vite build process to correctly resolve and bundle the main application script, which is necessary for a successful deployment to GitHub Pages. An absolute path breaks the build when the site is served from a subdirectory.