### PR TITLE
docs: Add lint and format commands to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,18 @@ npm run coverage
 
 This project uses **Prettier** and **ESLint** to enforce a consistent code style. Configuration files for Prettier and ESLint are included in the repository.
 
+To check for linting errors, run:
+
+```bash
+npm run lint
+```
+
+To automatically fix formatting and linting issues, run:
+
+```bash
+npm run format
+```
+
 Please ensure your code adheres to these styles. It's recommended to integrate Prettier and ESLint into your editor to format code automatically on save.
 
 ## 5. Commit Messages

--- a/README.md
+++ b/README.md
@@ -128,6 +128,41 @@ noch nicht implementiert (auch schwierig auf dem Handy umzusetzen).
 - **G**rafisch
 - **A**ssoziativ
 
+## Entwicklung (Development)
+
+Dieses Projekt wurde mit React, TypeScript und Vite erstellt.
+
+### Voraussetzungen
+
+- Node.js
+- npm
+
+### Installation
+
+Um die Abhängigkeiten zu installieren, führe folgenden Befehl aus:
+
+```bash
+npm install
+```
+
+### Lokaler Entwicklungsserver
+
+Um den lokalen Entwicklungsserver zu starten, führe folgenden Befehl aus:
+
+```bash
+npm run dev
+```
+
+Der Server ist unter `http://localhost:5173` erreichbar.
+
+### Tests
+
+Um die Tests auszuführen, verwende folgenden Befehl:
+
+```bash
+npm run test
+```
+
 ## Copyright
 
 Die vorgestellten Themen wurden nicht von mir erfunden, sondern von der


### PR DESCRIPTION
This change adds the `npm run lint` and `npm run format` commands to the `AGENTS.md` file under the "Coding Style" section. This provides clear instructions for developers on how to check and fix code style issues.